### PR TITLE
RIDER-3329 manifest에 exported 추가 - SDK31 설치 오류 대응

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
                 android:resource="@xml/syncadapter"/>
         </service>
         <service
-            android:name="com.marianhello.bgloc.sync.AuthenticatorService">
+            android:name="com.marianhello.bgloc.sync.AuthenticatorService" android:exported="true">
             <intent-filter>
                 <action android:name="android.accounts.AccountAuthenticator"/>
             </intent-filter>


### PR DESCRIPTION
[개요]
[RIDER-3326]에 의해서 라이브러리 업그레이드 필요

[문제]
갤럭시 폴드에서 설치 시 아래 오류가 발생함
Execution failed for task ':app:installLiveDebug'.
2> java.util.concurrent.ExecutionException: com.android.builder.testing.api.DeviceException: com.android.ddmlib.InstallException: INSTALL_PARSE_FAILED_MANIFEST_MALFORMED: Failed parse during installPackageLI: /data/app/vmdl1623386515.tmp/base.apk (at Binary XML file line #104): com.olulo.kickgoing.MainActivity: Targeting S+ (version 31 and above) requires that an explicit value for android:exported be defined when intent filters are present

- APK로 만들어도 설치가 되지 않음

[작업]
원래 라이브러리가 대응되어 있지 않아서 Fork 진행

[테스트]
테스트폰 갤럭시 폴드에서 설치 진행 완료

[관련 자료]
- https://codechacha.com/ko/android-12-intent-filter-explicit-exported/

[RIDER-3326]: https://olulo.atlassian.net/browse/RIDER-3326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ